### PR TITLE
Add support for non-x86-64 systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dump_vdso
 
-A simple tool to dump the VDSO(7) on X86_64 Linux systems.
+A simple tool to dump the VDSO(7) on Linux systems.
 
 Derived from code posted by Davin McCall in this Stack Overflow answer:
 https://stackoverflow.com/questions/49071746/how-to-get-the-size-of-the-vdso-on-a-linux-x86-64-system

--- a/dump_vdso.c
+++ b/dump_vdso.c
@@ -146,9 +146,7 @@ int main(int argc, char **argv)
            vdso_len;
 
     if(argc < 2)
-    {
         usage(argv[0]);
-    }
 
     /* Get the start virtual address of the VDSO */
     hdr = vdso_start = (void *)getauxval(AT_SYSINFO_EHDR);
@@ -185,9 +183,7 @@ int main(int argc, char **argv)
 
 clean:
     if(fh)
-    {
         fclose(fh);
-    }
 
     return ret;
 }


### PR DESCRIPTION
Make compliant with ANSI C and, as a result, change C++-style comments to C ones.
Improve formatting.
Use more portable types.
The only issue I might have with this is that it duplicates all the code; however, I deem this necessary to include both 32-bit and 64-bit support. The resulting assembly also differs.
Fix a few bugs; see line 116 before this PR.

The branch name is a bit misleading; I named it before realizing what a job making it possible to run this on 32-bit was.